### PR TITLE
ci: rename linter job name to plural

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   lint:
-    name: Run linter
+    name: Run linters
     runs-on: ubuntu-latest
     timeout-minutes: 10
 


### PR DESCRIPTION
## Summary
- Fix the lint CI job name from "Run linter" to "Run linters"