### PR TITLE
ci: use codecov-action for test results

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -61,9 +61,10 @@ jobs:
         run: pnpm test --ci --reporters=default --reporters=github-actions --reporters=jest-junit
 
       - name: Upload test results to Codecov
-        uses: codecov/test-results-action@v1
+        uses: codecov/codecov-action@v7
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+          report_type: test_results
 
       - name: Upload code coverage to codecov
         uses: codecov/codecov-action@v7


### PR DESCRIPTION
`codecov/test-results-action` is deprecated. This migrates the test-results upload to `codecov/codecov-action@v7` with `report_type: test_results` — the same action already used for the coverage upload in the step right below.

No behaviour change: same token, same auto-discovered JUnit report.