### PR TITLE
chore(deps): stop @types/node major bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,12 @@ updates:
     versioning-strategy: increase
     schedule:
       interval: weekly
+    ignore:
+      # Track the Node.js runtime major (24.x, see .node-version).
+      # Bump deliberately when the runtime moves to a new major.
+      - dependency-name: "@types/node"
+        update-types:
+          - version-update:semver-major
     groups:
       jest:
         patterns:


### PR DESCRIPTION
`@types/node` must track the Node.js runtime major — the project targets **Node 24** and type defs ahead of the runtime type-check code against APIs that don't exist in production.

This adds a dependabot `ignore` rule for `@types/node` semver-major bumps, so it keeps getting 24.x minor/patch updates only. The declared version is already on `^24`, so nothing else changes here.

Bump it deliberately, together with `.node-version` / `engines` / `@tsconfig/nodeXX`, when the runtime itself moves to a new major.